### PR TITLE
Removed memory leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ dmypy.json
 _qdldl.c
 libqdldl*
 *.DS_Store
+scratch/

--- a/cpp/qdldl.cpp
+++ b/cpp/qdldl.cpp
@@ -86,6 +86,7 @@ QDLDL_float * Solver::solve(QDLDL_float * b){
     QDLDL_solve(nx, Lp, Li, Lx, Dinv, work);
     permutet_x(nx, x, work, P);
 
+	delete [] work;
 	return x;
 
 }

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -28,7 +28,11 @@ py::array PySolver::solve(
 	auto x = s->solve(b);
     py::gil_scoped_acquire acquire;
 
-    return py::array(s->nx, x);
+	py::array x_py = py::array(s->nx, x);
+
+	delete [] x;
+
+    return x_py;
 }
 
 void PySolver::update(const py::object Anew){


### PR DESCRIPTION
Fixes #5. The script

```python
import scipy.sparse as sp
import numpy as np
import qdldl as ldl

N = int(1e4)
runs = int(1e5)

A = sp.eye(N, format='csc', dtype='float64')
b = np.random.randn(N)

F = ldl.Solver(A)
# memory usage is fine up to this point

# memory usage goes through the roof with many repeated solves
for i in range(runs):
    F.solve(b)
```

was causing a memory leak. 

From `memory_profiler`:
![mem_leak](https://user-images.githubusercontent.com/5514200/81622556-43938780-93bf-11ea-82b2-ec01673c4da9.png)

after this PR:

![no_mem_leak](https://user-images.githubusercontent.com/5514200/81622565-4a21ff00-93bf-11ea-9043-54886f6904cc.png)
