### PR TITLE
Add support for properly disabling the DLONG support

### DIFF
--- a/c/amd/include/SuiteSparse_config.h
+++ b/c/amd/include/SuiteSparse_config.h
@@ -43,7 +43,7 @@ extern "C" {
 #endif
 
 #include "qdldl_types.h"
-#define DLONG
+#include "qdldl_configure.h"
 typedef QDLDL_float c_float;
 
 #include <limits.h>

--- a/cpp/qdldl.cpp
+++ b/cpp/qdldl.cpp
@@ -1,5 +1,6 @@
 #include "qdldl.hpp"
 
+#include "qdldl/include/qdldl_configure.h"
 using namespace qdldl;
 
 
@@ -31,7 +32,11 @@ Solver::Solver(QDLDL_int n, QDLDL_int * Ap, QDLDL_int *Ai, QDLDL_float * Ax){
 	Pinv = new QDLDL_int[n];
 
 	// Permutation
+#ifdef DLONG
 	QDLDL_int amd_status = amd_l_order(nx, Ap, Ai, P, NULL, NULL);
+#else
+	QDLDL_int amd_status = amd_order(nx, Ap, Ai, P, NULL, NULL);
+#endif
 	if (amd_status < 0)
 		throw std::runtime_error(std::string("Error in AMD computation ") + std::to_string(amd_status));
 


### PR DESCRIPTION
This fixes the compile error on systems where `QDLDL_int` is a 32-bit integer instead of a 64-bit integer. The problem is that the `DLONG` flag was being always defined in the code, and that then the qdldl interface code was always calling the long version of the `amd_order` instead of the one for the size of the integer. I have tested this on a 32-bit Beaglebone Black and my 64-bit Fedora machine and it compiles on both. (I can't run the tests on the 32-bit machine because I don't have Python >3.7).

Note that this will depend on PR https://github.com/oxfordcontrol/qdldl/pull/37 being merged into QDLDL and then being included here. In the mean time, it can be tested with the proposed QDLDL fix by running the following commands inside the qdldl submodule
```
git remote add imremote https://github.com/imciner2/qdldl.git
git fetch imremote
git checkout im/confheader
```

Fixes https://github.com/oxfordcontrol/qdldl-python/issues/15