### PR TITLE
Update macOS version in CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,8 +43,8 @@ jobs:
             cibw_archs: "aarch64"
           - os: windows-2022
             cibw_archs: "auto64"
-          # Include macos-13 to get Intel x86_64 macs and maos-latest to get the Aaarch64 macs
-          - os: macos-13
+          # Include macos-15-intel to get Intel x86_64 macs and macos-latest to get the Aarch64 macs
+          - os: macos-15-intel
             cibw_archs: "x86_64"
           - os: macos-latest
             cibw_archs: "arm64"


### PR DESCRIPTION
macOS 15 is the last supported macOS runner with x64 architecture.