### PR TITLE
Add Windows arm64 wheel support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,8 @@ jobs:
             cibw_archs: "aarch64"
           - os: windows-2022
             cibw_archs: "auto64"
+          - os: windows-11-arm
+            cibw_archs: "ARM64"
           # Include macos-15-intel to get Intel x86_64 macs and macos-latest to get the Aarch64 macs
           - os: macos-15-intel
             cibw_archs: "x86_64"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,8 +43,10 @@ jobs:
             cibw_archs: "aarch64"
           - os: windows-2022
             cibw_archs: "auto64"
+            cmake_gen_platform: "x64"
           - os: windows-11-arm
             cibw_archs: "ARM64"
+            cmake_gen_platform: "ARM64"
           # Include macos-15-intel to get Intel x86_64 macs and macos-latest to get the Aarch64 macs
           - os: macos-15-intel
             cibw_archs: "x86_64"
@@ -77,7 +79,8 @@ jobs:
         CIBW_ENABLE: cpython-freethreading
         CIBW_BUILD: "cp3*"
         CIBW_ARCHS: ${{ matrix.cibw_archs }}
-        CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
+        # Numpy is not built for Windows ARM64 on Python <3.11
+        CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_* cp39-win_arm64 cp310-win_arm64"
         CIBW_TEST_REQUIRES: "pytest"
         CIBW_TEST_COMMAND: "pytest {project}/tests"
         # Skip testing on arm64 Python 3.8 because it uses the x86_64 executable, not the arm executable
@@ -87,7 +90,7 @@ jobs:
           rm -rf {package}/c/build
         CIBW_ENVIRONMENT_LINUX: CMAKE_GENERATOR="Unix Makefiles"
         CIBW_ENVIRONMENT_MACOS: CMAKE_GENERATOR="Unix Makefiles" CMAKE_OSX_ARCHITECTURES=${{ matrix.cibw_archs }}
-        CIBW_ENVIRONMENT_WINDOWS: CMAKE_GENERATOR="Visual Studio 17 2022" CMAKE_GENERATOR_PLATFORM=x64
+        CIBW_ENVIRONMENT_WINDOWS: CMAKE_GENERATOR="Visual Studio 17 2022" CMAKE_GENERATOR_PLATFORM=${{ matrix.cmake_gen_platform }}
         CIBW_BUILD_VERBOSITY: 1
 
     - name: Upload artifacts to github


### PR DESCRIPTION
This is technically experimental in cibuildwheel still (has been since Python 3.9), but we have public runners for Windows 11 arm64, so we can natively build it.