### PR TITLE
Update packaging when trying to upload to pypi

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,6 +120,9 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.pypi_password }}
+        # Need to ensure both twine and packaging are updated to twine 6.2+ and packaging 25+
+        # to work around https://github.com/pypa/twine/issues/1216
         run: |
+          python -m pip install --upgrade packaging
           python -m pip install --upgrade twine
           twine upload dist/*


### PR DESCRIPTION
An error occurred while trying to upload the 0.1.9 release to pypi just now (https://github.com/osqp/qdldl-python/actions/runs/22152548280/job/64049297717): 
```
Uploading distributions to https://upload.pypi.org/legacy/
ERROR    InvalidDistribution: Invalid distribution metadata: unrecognized or    
         malformed field 'license-file'                                         
```

Some digging shows this is related to versioning with twine and packaging, and according to https://github.com/pypa/twine/issues/1216#issuecomment-3714050419, we should ensure we update twine to 6.2+ and packaging to 25+. Twine was already being updated, so this adds an explicit update for packaging.